### PR TITLE
MATLAB version check for clim/caxis

### DIFF
--- a/code/mrisim_draw_m_vectors.m
+++ b/code/mrisim_draw_m_vectors.m
@@ -47,7 +47,11 @@ classdef mrisim_draw_m_vectors < mrisim_draw
             set(gca,'fontsize', 15);
 
             colormap hot;
-            clim([0 numel(mr_sim.spin_sys.vis_ind)+1]);
+            if isMATLABReleaseOlderThan('R2022a')
+                caxis([0 numel(mr_sim.spin_sys.vis_ind)+1]);
+            else
+                clim([0 numel(mr_sim.spin_sys.vis_ind)+1]);
+            end
 
             title('Magnetisation vectors');
 


### PR DESCRIPTION
The `clim` function was called `caxis` before 2022a (I'm running 2021b). Simple fix to check for that.

https://www.mathworks.com/help/matlab/ref/clim.html